### PR TITLE
增加gitignore macos相关项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ uploads/
 app.log
 build/
 dist/
+
+# MACOS
+.DS_Store
+._*


### PR DESCRIPTION
把
# MACOS
.DS_Store
._*
添加到gitignore中，避免macos垃圾文件混入