### PR TITLE
fix(router): standardize API route path by removing duplicate slashes

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,10 +1,11 @@
 package router
 
 import (
-	"github.com/gin-gonic/gin"
 	"krillin-ai/internal/handler"
 	"krillin-ai/static"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 func SetupRouter(r *gin.Engine) {
@@ -13,7 +14,7 @@ func SetupRouter(r *gin.Engine) {
 	hdl := handler.NewHandler()
 	{
 		api.POST("/capability/subtitleTask", hdl.StartSubtitleTask)
-		api.GET("/capability//subtitleTask", hdl.GetSubtitleTask)
+		api.GET("/capability/subtitleTask", hdl.GetSubtitleTask)
 		api.POST("/file", hdl.UploadFile)
 		api.GET("/file/*filepath", hdl.DownloadFile)
 	}


### PR DESCRIPTION
In the route definition for subtitle task API, there is a redundant slash in the path:

`/capability//subtitleTask`