### PR TITLE
fix: failed to translate when video clip is music

### DIFF
--- a/internal/service/audio2subtitle.go
+++ b/internal/service/audio2subtitle.go
@@ -953,10 +953,21 @@ func parseAndCheckContent(splitContent, originalText string) ([]TranslatedItem, 
 
 	// 处理无文本标记
 	if strings.Contains(splitContent, "[无文本]") {
-		if len(strings.TrimSpace(originalText)) < 10 {
+		// 检查原始文本是否是音乐标记或类似内容
+		lowerOriginal := strings.ToLower(strings.TrimSpace(originalText))
+		if len(lowerOriginal) < 30 && (strings.Contains(lowerOriginal, "music") ||
+			strings.Contains(lowerOriginal, "playing") ||
+			strings.Contains(lowerOriginal, "♪") ||
+			strings.Contains(lowerOriginal, "♫") ||
+			len(lowerOriginal) < 10) {
+			// 如果原始文本是音乐标记或很短，则返回空结果
 			return result, nil
 		} else {
-			return nil, errors.New("originalText is not empty but splitContent contains [无文本]")
+			// 记录警告但不返回错误，允许处理继续
+			log.GetLogger().Warn("originalText might contain actual content but splitContent contains [无文本]",
+				zap.String("originalText", originalText),
+				zap.String("splitContent", splitContent))
+			return result, nil
 		}
 	}
 


### PR DESCRIPTION
当文件视频片段中出现一段音乐，没有人声时，whisper识别后可能是Music Playing，大模型翻译后为无文本，超过了原代码10个字符的限制，会报错，添加对这种情况的处理
![image](https://github.com/user-attachments/assets/8a01d2ea-e495-48e5-8e52-44d8b750938d)
